### PR TITLE
Validate Matrix homeserver URL and fail-fast on config errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The project is organized using a hexagonal architecture:
 
 * The bot runs inside its **own asyncio loop**
 * All reconnects and restarts are automatic
-* Matrix outages are handled silently with backoff
+* Matrix outages are handled silently with backoff (configuration errors fail fast)
 * TS3 socket drops are detected within ~12 seconds
 * Presence reconciliation runs every 10 seconds
 
@@ -257,7 +257,7 @@ If you see errors like `unable to create temporary file`, check the following:
 
 ### Matrix or TS3 connection loops
 
-* Verify required `.env` values are present and valid.
+* Verify required `.env` values are present and valid (invalid Matrix homeserver URLs now stop the bot with a clear error).
 * Use `--debug` to see retry/backoff logs.
 
 ---

--- a/tests/test_matrix_homeserver.py
+++ b/tests/test_matrix_homeserver.py
@@ -1,0 +1,69 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+from aiohttp.client_exceptions import ClientConnectorError
+
+from tsmatrix_notify.config import ConfigError
+from tsmatrix_notify.main import (
+    build_matrix_creds,
+    is_transient_matrix_error,
+    validate_and_normalize_homeserver,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("https://matrix.example.com", "https://matrix.example.com"),
+        ("https://matrix.example.com/", "https://matrix.example.com"),
+    ],
+)
+def test_validate_and_normalize_homeserver_valid(raw, expected):
+    log = logging.getLogger("test")
+    assert validate_and_normalize_homeserver(raw, log) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["matrix.example.com", "", "   ", "ftp://matrix.example.com", "https://"],
+)
+def test_validate_and_normalize_homeserver_invalid(raw, caplog):
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ConfigError):
+            validate_and_normalize_homeserver(raw, log)
+    assert any("Invalid Matrix homeserver" in record.message for record in caplog.records)
+
+
+def test_build_matrix_creds_reads_homeserver_once():
+    class FlakyHomeserver:
+        def __init__(self):
+            self.calls = 0
+
+        def __str__(self):
+            self.calls += 1
+            if self.calls == 1:
+                return "https://matrix.example.com"
+            return "not-a-url"
+
+    hs = FlakyHomeserver()
+    matrix_config = SimpleNamespace(
+        homeserver=hs,
+        user_id="@bot:example.com",
+        access_token="token",
+        session_file="session.json",
+    )
+    log = logging.getLogger("test")
+    normalized, creds = build_matrix_creds(matrix_config, log)
+    assert hs.calls == 1
+    assert normalized == "https://matrix.example.com"
+    assert creds.homeserver == "https://matrix.example.com"
+
+
+def test_is_transient_matrix_error():
+    conn_key = SimpleNamespace(host="matrix.example.com", port=443, ssl=None)
+    connector_error = ClientConnectorError(conn_key, OSError("boom"))
+    assert is_transient_matrix_error(TimeoutError("timeout")) is True
+    assert is_transient_matrix_error(connector_error) is True
+    assert is_transient_matrix_error(ConfigError("Invalid Matrix homeserver: 'bad'")) is False

--- a/tsmatrix_notify/main.py
+++ b/tsmatrix_notify/main.py
@@ -7,6 +7,7 @@ import logging
 import random
 import sys
 import time
+from urllib.parse import urlparse
 
 import aiohttp
 from dotenv import load_dotenv
@@ -84,6 +85,7 @@ async def probe_homeserver(hs: str, log: logging.Logger, timeout_s: int = 6) -> 
     if not hs:
         log.error("Matrix homeserver not configured")
         return False
+    log.debug("versions probe using homeserver=%r", hs)
     url = hs.rstrip("/") + "/_matrix/client/versions"
     try:
         async with aiohttp.ClientSession() as session:
@@ -124,28 +126,44 @@ def is_transient_matrix_error(exc: Exception) -> bool:
     transient_types = (asyncio.TimeoutError, TimeoutError, ClientConnectorError, ConnectionError)
     if isinstance(exc, transient_types):
         return True
-    if isinstance(exc, ValueError) and "Invalid Homeserver" in str(exc):
-        return True
     if isinstance(exc, Exception) and "M_UNKNOWN" in str(exc):
         return True
     return False
 
 
+def validate_and_normalize_homeserver(hs: str, log: logging.Logger) -> str:
+    raw = "" if hs is None else str(hs)
+    log.debug("Validating Matrix homeserver: %r", raw)
+    candidate = raw.strip()
+    parsed = urlparse(candidate)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed.netloc:
+        log.error("Invalid Matrix homeserver: %r", raw)
+        raise ConfigError(f"Invalid Matrix homeserver: {raw!r}")
+    normalized = candidate.rstrip("/")
+    if normalized != candidate:
+        log.debug("Normalized Matrix homeserver: %r -> %r", candidate, normalized)
+    return normalized
+
+
+def build_matrix_creds(matrix_config, log: logging.Logger, normalized_homeserver: str | None = None):
+    normalized_hs = normalized_homeserver or validate_and_normalize_homeserver(
+        matrix_config.homeserver, log
+    )
+    creds = botlib.Creds(
+        homeserver=normalized_hs,
+        username=matrix_config.user_id,
+        access_token=matrix_config.access_token,
+        session_stored_file=matrix_config.session_file,
+    )
+    return normalized_hs, creds
+
+
 def connect_matrix(creds, log):
-    while True:
-        try:
-            if not creds.homeserver or not str(creds.homeserver).strip().lower().startswith(("http://", "https://")):
-                raise ValueError("Invalid Homeserver")
-            log.debug("Initializing Matrix bot for %s", creds.username)
-            bot = botlib.Bot(creds)
-            log.info("Matrix bot created for %s", creds.username)
-            return bot
-        except ValueError as exc:
-            log.error("Matrix init failed: %s", exc)
-            time.sleep(5)
-        except Exception as exc:
-            log.error("Matrix init failed: %s", exc)
-            time.sleep(5)
+    log.debug("Initializing Matrix bot for %s (homeserver=%r)", creds.username, creds.homeserver)
+    bot = botlib.Bot(creds)
+    log.info("Matrix bot created for %s", creds.username)
+    return bot
 
 
 def run() -> int:
@@ -156,6 +174,7 @@ def run() -> int:
 
     try:
         config = load_config(log)
+        normalized_homeserver = validate_and_normalize_homeserver(config.matrix.homeserver, log)
     except ConfigError as exc:
         log.error("Configuration error: %s", exc)
         return 2
@@ -178,14 +197,11 @@ def run() -> int:
         ts3 = None
 
         try:
-            if config.matrix.homeserver:
-                main_loop.run_until_complete(await_homeserver_ready(config.matrix.homeserver, log))
+            if normalized_homeserver:
+                main_loop.run_until_complete(await_homeserver_ready(normalized_homeserver, log))
 
-            creds = botlib.Creds(
-                homeserver=config.matrix.homeserver,
-                username=config.matrix.user_id,
-                access_token=config.matrix.access_token,
-                session_stored_file=config.matrix.session_file,
+            _, creds = build_matrix_creds(
+                config.matrix, log, normalized_homeserver=normalized_homeserver
             )
             room_id = config.matrix.room_id
 
@@ -227,8 +243,8 @@ def run() -> int:
                 except Exception as exc:
                     log.warning("%s whoami: %r", tag, exc)
 
-            if config.matrix.homeserver:
-                main_loop.create_task(_matrix_http_versions(config.matrix.homeserver))
+            if normalized_homeserver:
+                main_loop.create_task(_matrix_http_versions(normalized_homeserver))
             main_loop.create_task(_matrix_whoami("post-connect"))
 
             def ts3_event_handler(event: TSEvent):
@@ -424,7 +440,7 @@ def run() -> int:
                         f"- TS3 target:                {ts3_target}\n"
                         f"- TS3 instance uptime:       {inst_uptime}\n"
                         f"- TS3 virtualserver uptime:  {vs_uptime}\n"
-                        f"- Matrix homeserver:         {config.matrix.homeserver}\n"
+                        f"- Matrix homeserver:         {normalized_homeserver}\n"
                         f"- Matrix user_id (whoami):   {mx_user_id}\n"
                         f"- Matrix room:               {room_id}\n"
                     )
@@ -502,6 +518,13 @@ def run() -> int:
                 log.info("Matrix main returned; restarting bridge.")
             main_loop.run_until_complete(shutdown_bot(bot, log))
 
+        except ConfigError as exc:
+            log.error("Configuration error: %s", exc)
+            try:
+                main_loop.run_until_complete(shutdown_bot(bot, log))
+            except Exception:
+                pass
+            return 2
         except Exception as exc:
             et = type(exc).__name__
             if is_transient_matrix_error(exc) or et in {"RestartBot"}:


### PR DESCRIPTION
### Motivation

- Eliminate an intermittent reconnect loop where a later `ValueError: Invalid Homeserver` was classified as transient after a successful `/_matrix/client/versions` probe, causing infinite restart/backoff.  
- Make homeserver handling deterministic by validating and normalizing the value once and ensuring the same normalized value is used for probes and client creation.  
- Improve observability for configuration problems with targeted (sanitized) debug logging showing `repr` of the homeserver.  
- Keep transient classification limited to true network/transient failures and treat invalid configuration as a non-transient (fail-fast) error.

### Description

- Add `validate_and_normalize_homeserver(hs, log)` that uses `urllib.parse.urlparse` to accept only `http`/`https` schemes, require a non-empty `netloc`, strip whitespace, and remove trailing slash for internal use.  
- Add `build_matrix_creds()` to produce normalized homeserver and `botlib.Creds`, log validation events, and ensure homeserver is read/normalized only once before probes and connect.  
- Remove the previous `ValueError('Invalid Homeserver')` string-match from `is_transient_matrix_error()` and raise `ConfigError` on invalid homeserver so the process fails fast with a clear error (exit code `2`) instead of retrying.  
- Add `tests/test_matrix_homeserver.py` covering valid/invalid inputs, flaky homeserver objects, and transient error classification, and update README to note configuration errors now fail fast.

### Testing

- Ran `pytest` and all tests passed (`28 passed` in the run reported).  
- New tests cover `validate_and_normalize_homeserver` valid and invalid inputs and ensure `build_matrix_creds` reads the homeserver once.  
- Added tests verify `is_transient_matrix_error` returns `True` for network transient errors and `False` for `ConfigError` invalid-homeserver cases.  
- Tests use only fakes/mocks and do not require real TeamSpeak or Matrix servers; run them via `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696576403f64832cb79f0b775893f683)