### PR TITLE
Matrix resilience watchdog improvements and structured correlation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ helm pull oci://ghcr.io/colonelkrud/charts/tsmatrix-notify --version <chart-vers
 
 - **TS3 reconnect supervisor** monitors the TS3 receive loop and treats recv-thread exits as a fault condition. On failure it emits `TS3 reconnecting…` logs and retries with bounded backoff until the adapter is healthy again.
 - **Matrix resilience** starts with a homeserver `/versions` probe (`versions probe` in logs) before long-running sync usage. Transient failures (timeouts, temporary transport errors, 5xx responses) are retried; non-transient failures (invalid config/auth/permanent protocol errors) fail fast so operators can intervene.
-- **Sync-rate watchdog** (optional `--watchdog`) detects stalled Matrix sync activity and triggers a supervised restart path. Look for `sync-rate watchdog` log lines indicating degraded cadence and restart attempts.
+- **Sync-rate watchdog** (optional `--watchdog`) tracks the last successful Matrix sync timestamp and per-interval sync counts. When no syncs occur across the configured interval threshold, it emits `matrix_sync_stalled` with `last_successful_sync_at`, `seconds_since_last_sync`, `sync_count`, and `configured_threshold`, then restarts the Matrix loop.
+- **Structured restart reasons** are emitted as stable log messages/fields: `matrix_sync_stalled`, `matrix_sync_exception`, `matrix_send_failure`, and `shutdown_requested`.
+- **Correlation IDs** are generated for each TS3 notify and carried through TS3 receive, domain translation, dispatch decision, Matrix send attempt, and Matrix send success/failure logs via `correlation_id`.
 - **Failure-injection test coverage** validates these behaviors using deterministic fakes from PR #21. Run with:
 
 ```bash
@@ -137,9 +139,10 @@ python -m pytest -q
 ### Troubleshooting checklist
 
 1. Confirm configuration validation passes (homeserver URL, user ID, room ID, secrets).
-2. Search logs for `TS3 reconnecting…`, `versions probe`, and `sync-rate watchdog` to identify which supervisor path is active.
-3. If reconnect loops persist, verify TS3 query credentials/network reachability and Matrix token validity.
-4. Re-run `python -m pytest -q` locally to verify regressions are not introduced before redeploying.
+2. Search logs for `TS3 reconnecting…`, `versions probe`, `matrix_sync_stalled`, `matrix_sync_exception`, and `matrix_send_failure` to identify which supervisor path is active.
+3. Trace individual TS3→Matrix deliveries by filtering logs on `correlation_id=<id>` and checking `ts3_notify_received` → `dispatch_decision` → `matrix_send_attempt` / `matrix_send_success` or `matrix_send_failure`.
+4. If reconnect loops persist, verify TS3 query credentials/network reachability and Matrix token validity.
+5. Re-run `python -m pytest -q` locally to verify regressions are not introduced before redeploying.
 
 ## CI and release workflows
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -12,7 +12,7 @@ def test_send_actions_handles_failures(caplog):
     with caplog.at_level(logging.WARNING):
         send_actions(matrix, actions, logging.getLogger("test"))
 
-    assert "Matrix send failed" in caplog.text
+    assert "matrix_send_failure" in caplog.text
 
 
 def test_send_actions_if_ready_skips_when_not_ready(caplog):
@@ -25,3 +25,19 @@ def test_send_actions_if_ready_skips_when_not_ready(caplog):
 
     assert matrix.messages == []
     assert "Matrix not ready" in caplog.text
+
+
+def test_send_actions_logs_correlation_id(caplog):
+    matrix = FakeMatrix()
+    actions = [MatrixAction(room_id="room", text="hello", clid="1", correlation_id="corr-1", event_type="client_entered")]
+    with caplog.at_level(logging.INFO):
+        send_actions(matrix, actions, logging.getLogger("test"))
+    assert any(r.message == "matrix_send_success" and getattr(r, "correlation_id", None) == "corr-1" for r in caplog.records)
+
+
+def test_send_actions_failure_logs_correlation_id(caplog):
+    matrix = FakeMatrix(fail=True)
+    actions = [MatrixAction(room_id="room", text="hello", clid="1", correlation_id="corr-2", event_type="client_left")]
+    with caplog.at_level(logging.WARNING):
+        send_actions(matrix, actions, logging.getLogger("test"))
+    assert any(r.message == "matrix_send_failure" and getattr(r, "correlation_id", None) == "corr-2" for r in caplog.records)

--- a/tests/test_supervisors.py
+++ b/tests/test_supervisors.py
@@ -5,6 +5,7 @@ import threading
 from tsmatrix_notify.application.supervisors import (
     ExponentialBackoff,
     MatrixReconnectSupervisor,
+    SyncWatchdogState,
     TS3ReconnectSupervisor,
     make_ts3_thread_excepthook,
 )
@@ -79,3 +80,20 @@ def test_matrix_transient_error_uses_backoff():
     delay = supervisor.handle_error(asyncio.TimeoutError("timeout"))
 
     assert delay == 2.0
+
+
+def test_sync_watchdog_tracks_count_and_last_success():
+    state = SyncWatchdogState(stall_threshold_s=30)
+    state.mark_sync_success(100.0)
+    state.mark_sync_success(120.0)
+    assert state.last_successful_sync_at == 120.0
+    assert state.consume_interval_count() == 2
+    assert state.consume_interval_count() == 0
+
+
+def test_sync_watchdog_stall_context():
+    state = SyncWatchdogState(stall_threshold_s=60)
+    state.mark_sync_success(40.0)
+    context = state.stall_context(100.0)
+    assert context["restart_reason"] == "matrix_sync_stalled"
+    assert context["seconds_since_last_sync"] == 60.0

--- a/tsmatrix_notify/adapters/ts3_ts3api.py
+++ b/tsmatrix_notify/adapters/ts3_ts3api.py
@@ -4,6 +4,7 @@ import logging
 import socket
 import time
 import threading
+import uuid
 from typing import Callable
 
 from ts3API.TS3Connection import TS3Connection, TS3QueryException
@@ -191,6 +192,7 @@ class TS3APIAdapter(TS3Port):
             if ts_event is None:
                 self._log.debug("Unhandled TS3 event: %s", type(ev).__name__)
                 return
+            ts_event = TSEvent(ts_event.kind, ts_event.data, correlation_id=str(uuid.uuid4()))
             self._handler(ts_event)
 
         conn.register_for_server_events(on_ts3_event)

--- a/tsmatrix_notify/application/dispatcher.py
+++ b/tsmatrix_notify/application/dispatcher.py
@@ -7,11 +7,41 @@ from tsmatrix_notify.ports.matrix_port import MatrixPort
 
 
 def send_actions(matrix: MatrixPort, actions: list[MatrixAction], log: logging.Logger) -> None:
-    for action in actions:
+    for index, action in enumerate(actions, start=1):
+        log.info(
+            "matrix_send_attempt",
+            extra={
+                "correlation_id": action.correlation_id,
+                "event_type": action.event_type,
+                "ts3_client_id": action.clid,
+                "matrix_room_id": action.room_id,
+                "send_attempt": index,
+            },
+        )
         try:
             matrix.send_text(action.room_id, action.text, action.clid)
+            log.info(
+                "matrix_send_success",
+                extra={
+                    "correlation_id": action.correlation_id,
+                    "event_type": action.event_type,
+                    "ts3_client_id": action.clid,
+                    "matrix_room_id": action.room_id,
+                    "send_attempt": index,
+                },
+            )
         except Exception as exc:
-            log.warning("Matrix send failed for clid=%s: %r", action.clid, exc)
+            log.warning(
+                "matrix_send_failure",
+                extra={
+                    "correlation_id": action.correlation_id,
+                    "event_type": action.event_type,
+                    "ts3_client_id": action.clid,
+                    "matrix_room_id": action.room_id,
+                    "send_attempt": index,
+                    "error_type": type(exc).__name__,
+                },
+            )
 
 
 def send_actions_if_ready(matrix: MatrixPort, actions: list[MatrixAction], log: logging.Logger) -> None:

--- a/tsmatrix_notify/application/supervisors.py
+++ b/tsmatrix_notify/application/supervisors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import logging
 import random
 import threading
@@ -52,6 +53,36 @@ class ExponentialBackoff:
 
     def reset(self) -> None:
         self._current = None
+
+
+@dataclass
+class SyncWatchdogState:
+    stall_threshold_s: int = 60
+    sync_count: int = 0
+    last_successful_sync_at: float | None = None
+
+    def mark_sync_success(self, now: float) -> None:
+        self.last_successful_sync_at = now
+        self.sync_count += 1
+
+    def consume_interval_count(self) -> int:
+        count = self.sync_count
+        self.sync_count = 0
+        return count
+
+    def stall_context(self, now: float) -> dict[str, object]:
+        seconds_since = None if self.last_successful_sync_at is None else max(0.0, now - self.last_successful_sync_at)
+        iso = (
+            None
+            if self.last_successful_sync_at is None
+            else datetime.fromtimestamp(self.last_successful_sync_at, tz=timezone.utc).isoformat()
+        )
+        return {
+            "restart_reason": "matrix_sync_stalled",
+            "last_successful_sync_at": iso,
+            "seconds_since_last_sync": seconds_since,
+            "configured_threshold": self.stall_threshold_s,
+        }
 
 
 class MatrixReconnectSupervisor:

--- a/tsmatrix_notify/domain/events.py
+++ b/tsmatrix_notify/domain/events.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 class TSEvent:
     kind: str
     data: dict
+    correlation_id: str | None = None
 
 
 CLIENT_ENTERED = "client_entered"

--- a/tsmatrix_notify/domain/handlers.py
+++ b/tsmatrix_notify/domain/handlers.py
@@ -21,6 +21,8 @@ class MatrixAction:
     room_id: str
     text: str
     clid: str | None = None
+    correlation_id: str | None = None
+    event_type: str | None = None
 
 
 def handle_ts_event(event: events.TSEvent, state: AppState, room_id: str, now: float) -> list[MatrixAction]:
@@ -69,7 +71,15 @@ def handle_ts_event(event: events.TSEvent, state: AppState, room_id: str, now: f
         state.join_times.pop(cldbid, None)
 
     if text:
-        actions.append(MatrixAction(room_id=room_id, text=text, clid=data.get("clid")))
+        actions.append(
+            MatrixAction(
+                room_id=room_id,
+                text=text,
+                clid=data.get("clid"),
+                correlation_id=event.correlation_id,
+                event_type=event.kind,
+            )
+        )
     return actions
 
 

--- a/tsmatrix_notify/main.py
+++ b/tsmatrix_notify/main.py
@@ -9,6 +9,7 @@ import signal
 import time
 from urllib.parse import urlparse
 import threading
+import uuid
 
 import aiohttp
 from dotenv import load_dotenv
@@ -27,6 +28,7 @@ from tsmatrix_notify.domain.state import AppState
 from tsmatrix_notify.application.dispatcher import send_actions, send_actions_if_ready
 from tsmatrix_notify.application.supervisors import (
     MatrixReconnectSupervisor,
+    SyncWatchdogState,
     TS3ReconnectSupervisor,
     install_ts3_thread_excepthook,
 )
@@ -218,7 +220,7 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
     messages, apologies = persistence.load_message_catalog()
 
     state = AppState()
-    sync_count_60s = 0
+    sync_watchdog = SyncWatchdogState(stall_threshold_s=60)
     matrix_supervisor = MatrixReconnectSupervisor(log)
     restart_delay: float | None = None
 
@@ -265,8 +267,7 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
             ts3_supervisor = TS3ReconnectSupervisor(ts3, ts3_restart_event, log)
 
             def _on_sync_response(resp: SyncResponse):
-                nonlocal sync_count_60s
-                sync_count_60s += 1
+                sync_watchdog.mark_sync_success(time.time())
 
             async def _matrix_http_versions(hs: str, timeout_s: int = 6):
                 url = hs.rstrip("/") + "/_matrix/client/versions"
@@ -297,7 +298,11 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
             main_loop.create_task(_matrix_whoami("post-connect"))
 
             def ts3_event_handler(event: TSEvent):
-                actions = handle_ts_event(event, state, room_id, time.time())
+                correlation_id = event.correlation_id or str(uuid.uuid4())
+                log.info("ts3_notify_received", extra={"correlation_id": correlation_id, "event_type": event.kind, "ts3_event": event.kind, "ts3_client_id": event.data.get("clid"), "ts3_client_name": event.data.get("client_nickname")})
+                translated = TSEvent(kind=event.kind, data=event.data, correlation_id=correlation_id)
+                actions = handle_ts_event(translated, state, room_id, time.time())
+                log.info("dispatch_decision", extra={"correlation_id": correlation_id, "event_type": event.kind, "matrix_room_id": room_id, "action_count": len(actions)})
                 send_actions(matrix, actions, log)
 
             ts3.register_event_handler(ts3_event_handler)
@@ -562,14 +567,14 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
             runtime["bot_task"] = bot_task
 
             async def _sync_rate_watchdog():
-                nonlocal sync_count_60s
                 try:
                     while True:
                         await asyncio.sleep(60)
-                        count = sync_count_60s
-                        sync_count_60s = 0
+                        count = sync_watchdog.consume_interval_count()
                         if startup_once.is_set() and count == 0:
-                            log.warning("sync-rate watchdog: no SyncResponse in last 60s; restarting Matrix loop.")
+                            ctx = sync_watchdog.stall_context(time.time())
+                            ctx["sync_count"] = count
+                            log.warning("matrix_sync_stalled", extra=ctx)
                             health_state.set_ready(False, "matrix sync stalled; restarting")
                             bot_task.cancel()
                             return
@@ -594,6 +599,7 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
             main_loop.run_until_complete(shutdown_bot(bot, log))
 
         except ConfigError as exc:
+            log.warning("matrix_sync_exception", extra={"restart_reason": "matrix_sync_exception", "error_type": type(exc).__name__})
             restart_delay = matrix_supervisor.handle_error(exc)
             try:
                 main_loop.run_until_complete(shutdown_bot(bot, log))
@@ -620,9 +626,11 @@ def run() -> int:  # pragma: no cover - exercised via integration/runtime execut
                         pass
                     restart_delay = matrix_supervisor.next_delay()
                     health_state.set_ready(False, "manual restart requested")
+                    log.warning("shutdown_requested", extra={"restart_reason": "shutdown_requested"})
                     log.warning("Restart requested; retrying in %.1fs", restart_delay)
                 else:
                     health_state.set_ready(False, f"error: {et}")
+                    log.warning("matrix_sync_exception", extra={"restart_reason": "matrix_sync_exception", "error_type": et})
                     restart_delay = matrix_supervisor.handle_error(exc)
                 try:
                     main_loop.run_until_complete(shutdown_bot(bot, log))

--- a/tsmatrix_notify/main.py
+++ b/tsmatrix_notify/main.py
@@ -56,7 +56,36 @@ def setup_logger(debug: bool, trace: bool):
     log = logging.getLogger("TSMatrixNotify")
     log.setLevel(lvl)
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)5s %(message)s"))
+    class _StructuredContextFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            for key in (
+                "correlation_id",
+                "event_type",
+                "ts3_event",
+                "ts3_client_id",
+                "ts3_client_name",
+                "matrix_room_id",
+                "restart_reason",
+                "sync_count",
+                "last_successful_sync_at",
+                "seconds_since_last_sync",
+                "send_attempt",
+                "error_type",
+            ):
+                if not hasattr(record, key):
+                    setattr(record, key, "-")
+            return True
+
+    handler.addFilter(_StructuredContextFilter())
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)5s %(message)s "
+            "corr=%(correlation_id)s event=%(event_type)s ts3_event=%(ts3_event)s "
+            "clid=%(ts3_client_id)s cname=%(ts3_client_name)s room=%(matrix_room_id)s "
+            "restart=%(restart_reason)s sync_count=%(sync_count)s last_sync=%(last_successful_sync_at)s "
+            "since_last=%(seconds_since_last_sync)s attempt=%(send_attempt)s err=%(error_type)s"
+        )
+    )
     log.addHandler(handler)
     if debug or trace:
         logging.getLogger("nio").setLevel(logging.DEBUG)


### PR DESCRIPTION
### Motivation
- Make Matrix sync/watchdog restart behavior observable, deterministic, and testable by tracking last successful sync and per-interval counts. 
- Provide end-to-end tracing for TS3 events by introducing stable correlation IDs that follow an event through translation, dispatch, and Matrix send attempts. 

### Description
- Closes #7
- Closes #14
- Introduced `SyncWatchdogState` to track `last_successful_sync_at`, per-interval `sync_count`, and produce a structured stall context (`restart_reason`, `last_successful_sync_at`, `seconds_since_last_sync`, `configured_threshold`).
- Wire watchdog state into the Matrix sync callback and replace the previous ad-hoc counter with `mark_sync_success` and `consume_interval_count`, emitting `matrix_sync_stalled` with context when thresholds are exceeded. 
- Add correlation IDs to `TSEvent` and `MatrixAction`, generate a UUID at TS3 notify receipt in the TS3 adapter, and log `ts3_notify_received` → `dispatch_decision`. 
- Emit structured send logs from the dispatcher: `matrix_send_attempt`, `matrix_send_success`, and `matrix_send_failure` with stable fields including `correlation_id`, `event_type`, `ts3_client_id`, `matrix_room_id`, `send_attempt`, and `error_type` on failures. 
- Update README to document stall detection, structured restart reasons, and how to trace a TS3→Matrix delivery by `correlation_id`. 
- Added unit tests for the watchdog state and for correlation-aware send logging and failure logging, and ensured tests use existing fakes/mocks (no live Matrix/TS3). 

### Testing
- Ran `python -m ruff check .` and it passed. 
- Ran `python -m mypy tsmatrix_notify` and it passed. 
- Attempted `python -m pytest -q --cov=tsmatrix_notify --cov-report=term-missing --cov-report=xml --cov-fail-under=85` but coverage plugin flags were not available in this environment so coverage collection could not be executed here. 
- Ran `python -m pytest -q` and the full unit test suite passed: `81 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e446b358832cb6ea8fedb227065f)